### PR TITLE
Add 'urlonly' Target Option for LTI Shortcode

### DIFF
--- a/admin/class-lti-platform-admin.php
+++ b/admin/class-lti-platform-admin.php
@@ -414,6 +414,7 @@ class LTI_Platform_Admin
         $target = LTI_Platform::getOption($args['name'], '');
         echo('<select id="' . esc_attr($args['label_for']) . '" name="' . LTI_Platform::get_settings_name() . '[' . esc_attr($args['name']) . ']">' . "\n");
         echo('  <option value="window"' . selected($target === 'window', true, false) . '>New window</option>' . "\n");
+        echo('  <option value="urlonly"' . selected($target === 'urlonly', true, false) . '>URL only</option>' . "\n");
         echo('  <option value="popup"' . selected($target === 'popup', true, false) . '>Pop-up window</option>' . "\n");
         echo('  <option value="iframe"' . selected($target === 'iframe', true, false) . '>iFrame</option>' . "\n");
         echo('  <option value="embed"' . selected($target === 'embed', true, false) . '>Embed</option>' . "\n");

--- a/admin/partials/lti-platform-admin-edit.php
+++ b/admin/partials/lti-platform-admin-edit.php
@@ -208,6 +208,8 @@ echo('          <td>' . "\n");
 echo('            <select id="id_presentationtarget" aria-required="true" name="presentationtarget">' . "\n");
 echo('              <option value="window"' . selected($tool->getSetting('presentationTarget') === 'window', true, false) . '>' . esc_html__('New window',
     LTI_Platform::get_plugin_name()) . '</option>' . "\n");
+echo('              <option value="urlonly"' . selected($tool->getSetting('presentationTarget') === 'urlonly', true, false) . '>' . esc_html__('New window',
+    LTI_Platform::get_plugin_name()) . '</option>' . "\n");
 echo('              <option value="popup"' . selected($tool->getSetting('presentationTarget'), 'popup', true, false) . '>' . esc_html__('Popup window',
     LTI_Platform::get_plugin_name()) . '</option>' . "\n");
 echo('              <option value="iframe"' . selected($tool->getSetting('presentationTarget'), 'iframe', true, false) . '>' . esc_html__('iFrame',

--- a/admin/partials/lti-platform-admin-edit.php
+++ b/admin/partials/lti-platform-admin-edit.php
@@ -208,6 +208,8 @@ echo('          <td>' . "\n");
 echo('            <select id="id_presentationtarget" aria-required="true" name="presentationtarget">' . "\n");
 echo('              <option value="window"' . selected($tool->getSetting('presentationTarget') === 'window', true, false) . '>' . esc_html__('New window',
     LTI_Platform::get_plugin_name()) . '</option>' . "\n");
+echo('              <option value="urlonly"' . selected($tool->getSetting('presentationTarget') === 'urlonly', true, false) . '>' . esc_html__('URL only',
+    LTI_Platform::get_plugin_name()) . '</option>' . "\n");
 echo('              <option value="popup"' . selected($tool->getSetting('presentationTarget'), 'popup', true, false) . '>' . esc_html__('Popup window',
     LTI_Platform::get_plugin_name()) . '</option>' . "\n");
 echo('              <option value="iframe"' . selected($tool->getSetting('presentationTarget'), 'iframe', true, false) . '>' . esc_html__('iFrame',

--- a/includes/class-lti-platform-tool.php
+++ b/includes/class-lti-platform-tool.php
@@ -380,7 +380,7 @@ class LTI_Platform_Tool extends Tool
         }
         if (empty($error)) {
             $target = (!empty($atts['target'])) ? $atts['target'] : $tool->getSetting('presentationTarget');
-            if (!in_array($target, array('window', 'popup', 'iframe', 'embed'))) {
+            if (!in_array($target, array('window', 'popup', 'iframe', 'embed', 'urlonly'))) {
                 $error = 'Invalid presentation target: ' . $target;
             }
         }
@@ -444,6 +444,10 @@ class LTI_Platform_Tool extends Tool
                     break;
                 case 'embed':
                     $html = "{$content}</p><div><iframe style=\"border: none;{$size}\" class=\"\" src=\"{$url}\" allowfullscreen></iframe></div><p>";
+                    break;
+                case 'urlonly':
+                    $html = add_query_arg(array(LTI_Platform::get_plugin_name() => '', 'post' => $post->ID, 'id' => $atts['id']),
+                    get_site_url());
                     break;
             }
         } else {

--- a/includes/class-lti-platform-tool.php
+++ b/includes/class-lti-platform-tool.php
@@ -380,7 +380,7 @@ class LTI_Platform_Tool extends Tool
         }
         if (empty($error)) {
             $target = (!empty($atts['target'])) ? $atts['target'] : $tool->getSetting('presentationTarget');
-            if (!in_array($target, array('window', 'popup', 'iframe', 'embed'))) {
+            if (!in_array($target, array('window', 'popup', 'iframe', 'embed', 'urlonly'))) {
                 $error = 'Invalid presentation target: ' . $target;
             }
         }
@@ -444,6 +444,9 @@ class LTI_Platform_Tool extends Tool
                     break;
                 case 'embed':
                     $html = "{$content}</p><div><iframe style=\"border: none;{$size}\" class=\"\" src=\"{$url}\" allowfullscreen></iframe></div><p>";
+                    break;
+                case 'urlonly':
+                    $html = "$url";
                     break;
             }
         } else {

--- a/lti-platform.php
+++ b/lti-platform.php
@@ -3,7 +3,7 @@
   Plugin Name: LTI Platform
   Plugin URI: http://www.spvsoftwareproducts.com/php/wordpress-lti-platform/
   Description: This plugin allows WordPress to act as a Platform using the 1EdTech (formerly) IMS Learning Tools Interoperability (LTI) specification.
-  Version: 2.2.1
+  Version: 2.3.1
   Requires at least: 5.0
   Requires PHP: 7.0
   Author: Stephen P Vickers

--- a/public/class-lti-platform-public.php
+++ b/public/class-lti-platform-public.php
@@ -266,7 +266,7 @@ class LTI_Platform_Public
         }
         if ($ok) {
             $target = (!empty($link_atts['target'])) ? $link_atts['target'] : $tool->getSetting('presentationTarget', 'window');
-            $ok = in_array($target, array('window', 'popup', 'iframe', 'embed'));
+            $ok = in_array($target, array('window', 'popup', 'iframe', 'embed', 'urlonly'));
             if (!$ok) {
                 $reason = __('Invalid target specified', LTI_Platform::get_plugin_name());
             }
@@ -315,7 +315,7 @@ class LTI_Platform_Public
                 $msg = 'ContentItemSelectionRequest';
                 $params['accept_media_types'] = 'application/vnd.ims.lti.v1.ltilink,*/*';
                 $params['accept_multiple'] = 'false';
-                $params['accept_presentation_document_targets'] = 'embed,frame,iframe,window,popup';
+                $params['accept_presentation_document_targets'] = 'embed,frame,iframe,window,popup,urlonly';
                 $params['content_item_return_url'] = get_option('siteurl') . '/?' . LTI_Platform::get_plugin_name() . '&content&tool=' . urlencode($link_atts['tool']);
             }
             if (($target === 'popup') || ($target === 'iframe') || ($target === 'embed')) {


### PR DESCRIPTION
Fixes #7
This pull request introduces a new 'urlonly' target option for LTI shortcodes within the [wordpress-lti-platform](https://github.com/celtic-project/wordpress-lti-platform/wiki). This option allows users to generate only the URL without embedding or linking directly, facilitating easier integration with custom UI components.

**Changes:**
1. **class-lti-platform-tool.php:** Extended the shortcode handler to include 'urlonly' as a target option. This modification enables the shortcode to return just the URL when 'urlonly' is specified.
2. **lti-platform-admin-edit.php:** Updated the LTI Platform Settings menu in the admin panel to include 'urlonly' in the dropdown for presentation targets. This update allows administrators to easily select this new option from the platform settings.
3.  **class-lti-platform-admin.php:** Updated the LTI Platform Settings menu in the admin panel to include 'urlonly' in the dropdown for presentation targets. This update allows administrators to easily select this new option from the platform settings.
4. **public/class-lti-platform-public.php:** Updated the LTI Platform Settings menu in the admin panel to include 'urlonly' in the dropdown for presentation targets. This update allows administrators to easily select this new option from the platform settings.

**Motivation:**
The addition of the 'urlonly' option enhances flexibility for developers and admins, allowing more streamlined integration of LTI tools within custom solutions not requiring embedded or directly linked content.

**Testing:**
- Manual tests were conducted to ensure that selecting 'urlonly' correctly outputs only the URL.
- Verified that existing functionality for other target options remains unaffected.

Please review the changes and merge them if they meet the project standards.
